### PR TITLE
turret QoL: pressing S will dismount you

### DIFF
--- a/Content.Server/_CombatRim/ControllableMob/ControllableMobSystem.cs
+++ b/Content.Server/_CombatRim/ControllableMob/ControllableMobSystem.cs
@@ -41,6 +41,7 @@ public sealed class ControllableMobSystem : EntitySystem
                     RevokeControl(contMob.CurrentEntityOwning.Value);
                     Comp<ControllerMobComponent>(contMob.CurrentEntityOwning.Value).Controlling = null;
                     _popupSystem.PopupEntity(Loc.GetString("device-control-out-of-range"), contMob.CurrentEntityOwning.Value, contMob.CurrentEntityOwning.Value);
+                    contMob.CurrentDeviceOwning = null;
                     contMob.CurrentEntityOwning = null;
                 }
             }

--- a/Content.Server/_CombatRim/ManualTurret/ManualTurretSystem.cs
+++ b/Content.Server/_CombatRim/ManualTurret/ManualTurretSystem.cs
@@ -24,6 +24,7 @@ using Robust.Server.Player;
 using Robust.Shared.Physics;
 using Content.Shared.Movement.Events;
 using Content.Server._CombatRim.ControllableMob.Components;
+using Content.Server._CombatRim.ControllableMob;
 
 namespace Content.Server._CombatRim.ManualTurret
 {
@@ -37,7 +38,7 @@ namespace Content.Server._CombatRim.ManualTurret
         [Dependency] private readonly ContainerSystem _containerSystem = default!;
         [Dependency] private readonly GunSystem _gunSystem = default!;
         [Dependency] private readonly SharedAppearanceSystem _appearanceSystem = default!;
-        [Dependency] private readonly CombatModeSystem _combatModeSystem = default!;
+        [Dependency] private readonly ControllableMobSystem _controllableMobSystem = default!;
         [Dependency] private readonly InputSystem _inputSystem = default!;
 
         public override void Initialize() // VERY IMPORTANT!!!!!!
@@ -91,6 +92,15 @@ namespace Content.Server._CombatRim.ManualTurret
                     comp.Rotation += comp.RotSpeed / 100;
                 if (input.GetState(EngineKeyFunctions.MoveRight) == BoundKeyState.Down)
                     comp.Rotation -= comp.RotSpeed / 100;
+
+                if (TryComp<ControllableMobComponent>(comp.Owner, out var contMob) && contMob.CurrentEntityOwning != null
+                    && input.GetState(EngineKeyFunctions.MoveDown) == BoundKeyState.Down)
+                {
+                    Comp<ControllerMobComponent>(contMob.CurrentEntityOwning.Value).Controlling = null;
+                    contMob.CurrentDeviceOwning = null;
+                    _controllableMobSystem.RevokeControl(contMob.CurrentEntityOwning.Value);
+                    contMob.CurrentEntityOwning = null;
+                }
             }
         }
 


### PR DESCRIPTION
...dismount? what the fuck pixel

<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

**Media**
<!-- 
If applicable, add screenshots or videos to showcase your PR. Small fixes/refactors are exempt, but all PRs which make ingame changes 
(adding clothing, items, new features, etc) must include ingame media or the PR will not be merged, in accordance with our PR guidelines.
This makes it much easier for us to merge PRs and find media for progress reports. If you include media in your pull request, we 
may potentially use it in the SS14 progress reports, with clear credit given.

Use screenshot software like Window's built in snipping tool, ShareX, Lightshot, or recording software like ShareX (gif), ScreenToGif, or Open Broadcaster Software (cross platform).
If you're unsure whether your PR will require media, ask a maintainer.

Check one of the boxes below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- add: Added fun!
- remove: Removed fun!

